### PR TITLE
Update regex in Userscript (again)

### DIFF
--- a/userscript.user.js
+++ b/userscript.user.js
@@ -5,7 +5,7 @@
 // @downloadURL  https://github.com/xF4b3r/krunker/raw/master/userscript.user.js
 // @version      3.3
 // @author       Faber, Tehchy
-// @include      /^https?:\/\/krunker\.io(|\/|\/\?server=.+)$/
+// @include      /^(https?:\/\/)?(www\.)?krunker\.io(|\/|\/\?server=.+)$/
 // @grant        GM_xmlhttpRequest
 // @run-at       document-start
 // ==/UserScript==


### PR DESCRIPTION
Allow url regex to support "http(s)://(www.)krunker.io(/?server=SERVER)"

Fixed tampermonkey not activated script for "https://www.krunker.io/?server=SERVER"